### PR TITLE
Upload Android mapping file for Google Play

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,11 +219,13 @@ jobs:
             -Pandroid.injected.signing.store.type=PKCS12 \
             --build-cache --no-daemon
 
-      - name: Upload artifact
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: app-release-aab
-          path: frontend-party-battle/android/app/build/outputs/bundle/release/app-release.aab
+          name: android-release
+          path: |
+            frontend-party-battle/android/app/build/outputs/bundle/release/app-release.aab
+            frontend-party-battle/android/app/build/outputs/mapping/release/mapping.txt
           if-no-files-found: error
 
   deploy-android:
@@ -234,7 +236,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v5
         with:
-          name: app-release-aab
+          name: android-release
           path: dist
 
       - name: Upload to Google Play (internal)
@@ -243,5 +245,6 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           packageName: ch.thirty_degrees.party_battle
           releaseFiles: dist/app-release.aab
+          mappingFile: dist/mapping.txt
           track: internal
           status: draft


### PR DESCRIPTION
## Summary
- upload mapping.txt from Android build artifacts
- forward mapping file to Google Play deploy step

## Testing
- `npm test --prefix backend-party-battle` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68b00e624b54832e9128aac9911dd794