### PR TITLE
fix: checkout repository for iOS deploy

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -79,6 +79,7 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: ios-release


### PR DESCRIPTION
## Summary
- checkout repository in iOS deploy job so `frontend-party-battle` exists

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bafea6b258832e9edb4dd89d9a4160