### PR TITLE
fix: exclude tests from backend build

### DIFF
--- a/backend-party-battle/tsconfig.json
+++ b/backend-party-battle/tsconfig.json
@@ -15,5 +15,9 @@
   },
   "include": [
     "src"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/__tests__"
   ]
 }


### PR DESCRIPTION
## Summary
- prevent backend test files from being emitted in production builds

## Testing
- `npm test --workspace=backend-party-battle`
- `npm run lint`
- `npm run check-types`
- `npm run docker:build --workspace=backend-party-battle` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_68c52b8590ac832e9767b585614339e9